### PR TITLE
Move sampling outside of the timer ISR

### DIFF
--- a/Firmware/OpenLog_Artemis_Geophone_Logger/Geophone.ino
+++ b/Firmware/OpenLog_Artemis_Geophone_Logger/Geophone.ino
@@ -67,6 +67,20 @@ void geophone_setup()
  */
 void sampling_interrupt( )
 {
+  sampleNow = true;
+}
+
+void checkSampleNow()
+{
+  if (sampleNow)
+  {
+    sampleNow = false;
+    getSample();
+  }
+}
+  
+void getSample()
+{
   /* Read a sample and store it in the geodata buffer.  Apply a Hamming
      window as we go along.  It involves a cos operation; the alternative
      is an array that should be fit into program memory. */

--- a/Firmware/OpenLog_Artemis_Geophone_Logger/OpenLog_Artemis_Geophone_Logger.ino
+++ b/Firmware/OpenLog_Artemis_Geophone_Logger/OpenLog_Artemis_Geophone_Logger.ino
@@ -168,6 +168,7 @@ const byte menuTimeout = 15; //Menus will exit/timeout after this number of seco
 volatile static bool samplingEnabled = true; // Flag to indicate if sampling is enabled (sampling is paused while the menu is open)
 volatile static bool stopLoggingSeen = false; //Flag to indicate if we should stop logging
 volatile static bool powerLossSeen = false; //Flag to indicate if a power loss event has been seen
+volatile static bool sampleNow = false; //Flag to indicate when to take an ADC sample. Sampling is done outside of the ISR
 
 //-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
 
@@ -325,7 +326,9 @@ void setup() {
 }
 
 void loop() {
-  
+
+  checkSampleNow();
+
   if (Serial.available()) // Check if the user pressed a key
   {
     samplingEnabled = false; // Disable sampling while menu is open
@@ -402,6 +405,8 @@ void loop() {
         // Don't change the limit unless you know what you are doing.
         while ((dataLength > 0) && (millis() < (writeStart + 1300)))
         {
+          checkSampleNow();
+          
           int bytesToWrite;
           if (dataLength > 512)
             bytesToWrite = 512;
@@ -473,6 +478,8 @@ void loop() {
       int thisByte = 0;
       while (dataLength > 0)
       {
+        checkSampleNow();
+        
         Serial.write(geophoneDataSerial[thisByte]);
         thisByte++;
         bytesSent++;


### PR DESCRIPTION
Hi RiskLogger,

The MbedOS Error is caused by reading the ADC (using I2C) _inside_ the timer Interrupt Service Routine. With version 1 of the core, this was possible. With version 2, it causes an error.

I have made some small changes so the ADC is now read by the main loop. The code now works - it does not crash - but I think the ADC sampling will not be as regular as before. I think the code will ignore or miss the timer interrupts while geophone_loop is performing the FFT, and while data is written to SD card or the Serial Plotter. It might be necessary to use a separate Thread to read the ADC?

Best wishes,
Paul
